### PR TITLE
v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: csharp
+mono: none
+dotnet: 2.0.0
+dist: trusty
+script:
+ - dotnet build ./src/UoN.VersionInformation.DependencyInjection -c Release
+ - dotnet pack ./src/UoN.VersionInformation.DependencyInjection -c Release --no-build
+after_success:
+ - |
+    (test $TRAVIS_BRANCH = "master" || test $TRAVIS_BRANCH = "prerelease") && \
+    test $TRAVIS_PULL_REQUEST = "false" && \
+    dotnet nuget push **/*.nupkg -k $NUGET_API_KEY -s https://www.nuget.org/api/v2/package

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # UoN.VersionInformation.DependencyInjection
-`IServiceCollection` extensions for using `UoN.VersionInformation` with .NET Core Dependency Injecton.
+
+[![License](https://img.shields.io/badge/licence-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://travis-ci.org/UniversityOfNottingham/UoN.VersionInformation.svg?branch=master)](https://travis-ci.org/UniversityOfNottingham/UoN.VersionInformation)
+[![NuGet](https://img.shields.io/nuget/v/UoN.VersionInformation.svg)](https://www.nuget.org/packages/UoN.VersionInformation/)
+
+# What is it?
+
+`IServiceCollection` extensions for using [UoN.VersionInformation](https://github.com/uon-nuget/UoN.VersionInformation) with .NET Core Dependency Injecton.
+
+# What are its features?
+
+## IServiceCollection Extensions
+
+The package provides 3 extension methods which add a `VersionInformationService` to an `IServiceCollection`.
+
+- One without options
+- Two that take options either as an object or a delegate.
+
+Refer to the sample application for example usage.
+
+# Dependencies
+
+The library targets `netstandard2.0` and depends on `Microsoft.Extensions.DependencyInjection` 2.0.0.
+
+# Building from source
+
+We recommend building with the `dotnet` cli, but since the package targets `netstandard2.0` and depends on `Microsoft.Extensions.DependencyInjection` 2.0.0, you should be able to build it in any tooling that supports those requirements.
+
+- Have the .NET Core SDK
+- `dotnet build`
+- Optionally `dotnet pack`
+- Reference the resulting assembly, or NuGet package.
+
+# Contributing
+
+If there are issues open, please feel free to make pull requests for them, and they will be reviewed.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # UoN.VersionInformation.DependencyInjection
 
 [![License](https://img.shields.io/badge/licence-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Build Status](https://travis-ci.org/UniversityOfNottingham/UoN.VersionInformation.svg?branch=master)](https://travis-ci.org/UniversityOfNottingham/UoN.VersionInformation)
-[![NuGet](https://img.shields.io/nuget/v/UoN.VersionInformation.svg)](https://www.nuget.org/packages/UoN.VersionInformation/)
+[![Build Status](https://travis-ci.org/uon-nuget/UoN.VersionInformation.DependencyInjection.svg?branch=master)](https://travis-ci.org/uon-nuget/UoN.VersionInformation.DependencyInjection)
+[![NuGet](https://img.shields.io/nuget/v/UoN.VersionInformation.DependencyInjection.svg)](https://www.nuget.org/packages/UoN.VersionInformation.DependencyInjection/)
 
 # What is it?
 

--- a/UoN.VersionInformation.DependencyInjection.sln
+++ b/UoN.VersionInformation.DependencyInjection.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2043
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UoN.VersionInformation.DependencyInjection", "src\UoN.VersionInformation.DependencyInjection\UoN.VersionInformation.DependencyInjection.csproj", "{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D8A92377-EB7F-48DB-A8E3-B89AA5B2E6B5}
+	EndGlobalSection
+EndGlobal

--- a/UoN.VersionInformation.DependencyInjection.sln
+++ b/UoN.VersionInformation.DependencyInjection.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.27428.2043
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UoN.VersionInformation.DependencyInjection", "src\UoN.VersionInformation.DependencyInjection\UoN.VersionInformation.DependencyInjection.csproj", "{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp", "samples\ConsoleApp\ConsoleApp.csproj", "{7297EE3E-35B8-4919-8095-778B3F673455}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBC8626F-A8AA-4F09-AF68-A616BB0A73AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7297EE3E-35B8-4919-8095-778B3F673455}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7297EE3E-35B8-4919-8095-778B3F673455}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7297EE3E-35B8-4919-8095-778B3F673455}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7297EE3E-35B8-4919-8095-778B3F673455}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/ConsoleApp/ConsoleApp.csproj
+++ b/samples/ConsoleApp/ConsoleApp.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\UoN.VersionInformation.DependencyInjection\UoN.VersionInformation.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using UoN.VersionInformation;
+using UoN.VersionInformation.DependencyInjection;
+using UoN.VersionInformation.Providers;
+
+namespace ConsoleApp
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            // Default options
+            var services = ConfigureServices_NoOptions(new ServiceCollection());
+
+            var version = services.GetRequiredService<VersionInformationService>();
+
+            Console.WriteLine(await version.EntryAssemblyAsync());
+
+            // Options object
+            services = ConfigureServices_OptionsObject(new ServiceCollection());
+
+            version = services.GetRequiredService<VersionInformationService>();
+
+            Console.WriteLine(await version.ByKeyAsync("Assembly"));
+
+            // Options Delegate
+            services = ConfigureServices_OptionsDelegate(new ServiceCollection());
+
+            version = services.GetRequiredService<VersionInformationService>();
+
+            Console.WriteLine(await version.ByKeyAsync("Assembly"));
+
+            Console.ReadKey();
+        }
+
+        private static IServiceProvider ConfigureServices_NoOptions(IServiceCollection services)
+        {
+            services.AddVersionInformation();
+            return services.BuildServiceProvider();
+        }
+
+        private static IServiceProvider ConfigureServices_OptionsObject(IServiceCollection services)
+        {
+            var options = new VersionInformationOptions
+            {
+                KeyHandlers = new Dictionary<string, IVersionInformationProvider>
+                {
+                    ["Assembly"] = new AssemblyInformationalVersionProvider()
+                }
+            };
+
+            services.AddVersionInformation(options);
+            return services.BuildServiceProvider();
+        }
+
+        private static IServiceProvider ConfigureServices_OptionsDelegate(IServiceCollection services)
+        {
+            services.AddVersionInformation(opts =>
+            {
+                opts.KeyHandlers.Add("Assembly", new AssemblyInformationalVersionProvider());
+            });
+            return services.BuildServiceProvider();
+        }
+    }
+}

--- a/src/UoN.VersionInformation.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/UoN.VersionInformation.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,6 @@
+﻿namespace UoN.VersionInformation.DependenyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+    }
+}

--- a/src/UoN.VersionInformation.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/UoN.VersionInformation.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,6 +1,24 @@
-﻿namespace UoN.VersionInformation.DependenyInjection
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace UoN.VersionInformation.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {
+        public static void AddVersionInformation(this IServiceCollection services)
+            => services.AddTransient<VersionInformationService>();
+
+        public static void AddVersionInformation(this IServiceCollection services,
+            VersionInformationOptions options)
+            => services.AddTransient(_ => new VersionInformationService(options));
+
+        public static void AddVersionInformation(
+            this IServiceCollection services,
+            Action<VersionInformationOptions> configureOptions)
+        {
+            var options = new VersionInformationOptions();
+            configureOptions.Invoke(options);
+            services.AddVersionInformation(options);
+        }
     }
 }

--- a/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
+++ b/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
+++ b/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
@@ -4,4 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageReference Include="UoN.VersionInformation" Version="1.0.0-beta3" />
+  </ItemGroup>
+
 </Project>

--- a/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
+++ b/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageVersion>1.0.0-beta1</PackageVersion>
+    <PackageVersion>1.0.0</PackageVersion>
 
     <Authors>UoN Application Development</Authors>
 
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="UoN.VersionInformation" Version="1.0.0-beta3" />
+    <PackageReference Include="UoN.VersionInformation" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
+++ b/src/UoN.VersionInformation.DependencyInjection/UoN.VersionInformation.DependencyInjection.csproj
@@ -2,6 +2,26 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageVersion>1.0.0-beta1</PackageVersion>
+
+    <Authors>UoN Application Development</Authors>
+
+    <Description>
+      `IServiceCollection` extensions for using `UoN.VersionInformation` with .NET Core Dependency Injection.
+    </Description>
+
+    <PackageReleaseNotes>
+      First release.
+    </PackageReleaseNotes>
+
+    <Copyright>Copyright 2018 (c) University of Nottingham.</Copyright>
+
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageIconUrl>https://raw.githubusercontent.com/uon-nuget/assets/master/nuget-package-icon.png</PackageIconUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/uon-nuget/UoN.VersionInformation.DependencyInjection/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/uon-nuget/UoN.VersionInformation.DependencyInjection</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/uon-nuget/UoN.VersionInformation.DependencyInjection</RepositoryUrl>
+    <PackageTags>uon version netstandard dependencyinjection</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This being a separate package to `UoN.VersionInformation` isolates the dependency on `Microsoft.Extensions.DependencyInjection`.

It also requires `netstandard2.0` due to that dependency.

This just provides the DI extension methods if people want them.